### PR TITLE
Use peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "author": "Boris Schaedler",
   "license": "MIT",
   "dependencies": {
-    "bufferutil": "^4.0.1",
     "debug": "^3.1.0",
     "node-cleanup": "^2.1.2",
     "node-roon-api": "github:roonlabs/node-roon-api",
@@ -16,8 +15,11 @@
     "node-roon-api-settings": "github:roonlabs/node-roon-api-settings",
     "node-roon-api-status": "github:roonlabs/node-roon-api-status",
     "node-roon-api-transport": "github:roonlabs/node-roon-api-transport",
-    "utf-8-validate": "^5.0.2",
     "ws": "^7.3.0"
+  },
+  "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": "^5.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi @bsc101,

Since the switch to `ws` in version 0.5.0 there is a compatibility issue with the Extension Manager on some Linux versions (noticed this on my Alpine based Docker image and on DietPi). The Extension Manager installs extensions globally using:

    npm install -g https://github.com/bsc101/roon-extension-itroxs.git

On the mentioned Linux systems there is an error reported during installation of the `bufferutil` dependency. There is something special with this dependency (and `utf-8-validate`) because in the `package.json` file of `ws` they are listed as (optional) peerDependencies, which means (in very short) that they should be installed manually. If I also list them as peerDependencies in it'roXs!, as done is this pull request, then the global installation is successful again. With this configuration the Extension Manager installs the peerDependencies in a second install step.

I don't know if this is the best solution, as that might depend on if you really rely on these dependencies. The `node-roon-api` also depends on `ws` but isn't specific about the peerDependencies, meaning that leaving them out can fix it as well.

Let me know your opinion about this.